### PR TITLE
fix: Fixing the argv parameter in most commands

### DIFF
--- a/scripts/enable-secret-scanning.js
+++ b/scripts/enable-secret-scanning.js
@@ -32,7 +32,7 @@ module.exports = {
             type: "bool",
         },
     },
-    action: async (octokit, argv) => {
+    action: async (octokit, _graphql, argv) => {
         const enablePushProtection = argv["enable-push-protection"];
         let repositories;
 

--- a/scripts/list-languages-in-organization.js
+++ b/scripts/list-languages-in-organization.js
@@ -18,7 +18,7 @@ module.exports = {
             type: "number",
         },
     },
-    action: async (octokit, argv) => {
+    action: async (octokit, _graphql, argv) => {
         const languagesInOrg = {};
 
         const repositories = await listAllRepositoriesInOrganization(octokit, argv.organization);

--- a/scripts/list-repos-with-file-extensions.js
+++ b/scripts/list-repos-with-file-extensions.js
@@ -16,7 +16,7 @@ module.exports = {
             type: "array",
         },
     },
-    action: async (octokit, argv) => {
+    action: async (octokit, _graphql, argv) => {
         const reposMatchingExtensions = {};
 
         const formattedExtensionsString = `+extension:${argv.extensions.join("+extension:")}`;

--- a/scripts/reassign-repository-roles.js
+++ b/scripts/reassign-repository-roles.js
@@ -20,7 +20,7 @@ module.exports = {
             type: "string",
         },
     },
-    action: async (octokit, argv) => {
+    action: async (octokit, _graphql, argv) => {
         const oldRole = argv["old-role"];
         const newRole = argv["new-role"];
 

--- a/scripts/reassign-team-roles.js
+++ b/scripts/reassign-team-roles.js
@@ -20,7 +20,7 @@ module.exports = {
             type: "string",
         },
     },
-    action: async (octokit, argv) => {
+    action: async (octokit, _graphql, argv) => {
         const oldRole = argv["old-role"];
         const newRole = argv["new-role"];
 


### PR DESCRIPTION
It would appear that a _graphql_ parameter was added for the _list-languages-in-enterprise_ command.  All commands were being passed this parameter and were not altered to handle it and therefore it incorrectly assigned the _argv_ parameter to the _graphql_ values