### PR TITLE
fix: correcting object overwrites

### DIFF
--- a/scripts/list-languages-in-organization.js
+++ b/scripts/list-languages-in-organization.js
@@ -37,7 +37,7 @@ module.exports = {
                 if (languagesInOrg[language] && percent >= argv.percent) {
                     languagesInOrg[language].count++;
                     languagesInOrg[language].repos.push(repository.name);
-                } else {
+                } else if(percent >= argv.percent) {
                     languagesInOrg[language] = {
                         count: 1,
                         repos: [repository.name],

--- a/scripts/list-languages-in-organization.js
+++ b/scripts/list-languages-in-organization.js
@@ -37,7 +37,7 @@ module.exports = {
                 if (languagesInOrg[language] && percent >= argv.percent) {
                     languagesInOrg[language].count++;
                     languagesInOrg[language].repos.push(repository.name);
-                } else if(percent >= argv.percent) {
+                } else if (percent >= argv.percent) {
                     languagesInOrg[language] = {
                         count: 1,
                         repos: [repository.name],


### PR DESCRIPTION
Without the added check, the object being created is continuously overwriting previous values.  Specifically, the case that the object exits (the language) from a previous repo, then...a matching object (language) is found in another repo but does not meet the percentage requirement.