### PR TITLE
feat: Create output file in JSON format for list-languages-in-organization script

### DIFF
--- a/scripts/list-languages-in-organization.js
+++ b/scripts/list-languages-in-organization.js
@@ -1,5 +1,5 @@
 const fs = require("fs");
-const { join } = require("path");
+const path = require("path");
 const { listAllRepositoriesInOrganization } = require("../util/github");
 
 const getTotalCodeSizeInBytes = (obj) => Object.values(obj).reduce((accumulator, value) => accumulator + value, 0);
@@ -29,14 +29,15 @@ module.exports = {
         const languagesInOrg = {};
         const currentDirectory = process.cwd();
         const date = new Date().toISOString();
-        const outputFilePath = argv.outputFilePath || join(currentDirectory, `languages-in-organization.${argv.organization}.${date}.json`);
+        const outputFilePath = argv.outputFilePath || path.join(currentDirectory, `languages-in-organization.${argv.organization}.${date}.json`);
 
         // check if argv.outputFilePath is set, if so check if the parent directory exists as we will not create it
         if (argv.outputFilePath) {
-            const parentDirectory = join(argv.outputFilePath, "..");
+            const parentDirectory = path.join(argv.outputFilePath, "..");
             // if the parent directory does not exist, exit the script
             if (!fs.existsSync(parentDirectory)) {
                 console.error(`The parent directory of the provided output file path does not exist: '${parentDirectory}'`);
+
                 return;
             }
         }
@@ -72,11 +73,13 @@ module.exports = {
         console.table(languagesInOrg);
 
         // Write results to file
-        fs.writeFile(outputFilePath, JSON.stringify(languagesInOrg, null, 2), (err) => {
+        fs.writeFile(outputFilePath, JSON.stringify(languagesInOrg, undefined, 2), (err) => {
             if (err) {
                 console.error(err);
+
                 return;
             }
+
             console.log(`Output file has been created: '${outputFilePath}'`);
         });
     },

--- a/scripts/list-languages-in-organization.js
+++ b/scripts/list-languages-in-organization.js
@@ -1,3 +1,5 @@
+const fs = require("fs");
+const { join } = require("path");
 const { listAllRepositoriesInOrganization } = require("../util/github");
 
 const getTotalCodeSizeInBytes = (obj) => Object.values(obj).reduce((accumulator, value) => accumulator + value, 0);
@@ -11,6 +13,11 @@ module.exports = {
             describe: "the GitHub organization to search for language usage",
             type: "string",
         },
+        outputFilePath: {
+            alias: "f",
+            describe: "the path of the output file to write the results to",
+            type: "string",
+        },
         percent: {
             alias: "p",
             default: 25,
@@ -20,6 +27,19 @@ module.exports = {
     },
     action: async (octokit, _graphql, argv) => {
         const languagesInOrg = {};
+        const currentDirectory = process.cwd();
+        const date = new Date().toISOString();
+        const outputFilePath = argv.outputFilePath || join(currentDirectory, `languages-in-organization.${argv.organization}.${date}.json`);
+
+        // check if argv.outputFilePath is set, if so check if the parent directory exists as we will not create it
+        if (argv.outputFilePath) {
+            const parentDirectory = join(argv.outputFilePath, "..");
+            // if the parent directory does not exist, exit the script
+            if (!fs.existsSync(parentDirectory)) {
+                console.error(`The parent directory of the provided output file path does not exist: '${parentDirectory}'`);
+                return;
+            }
+        }
 
         const repositories = await listAllRepositoriesInOrganization(octokit, argv.organization);
 
@@ -46,6 +66,18 @@ module.exports = {
             }
         }
 
+        // Print results to console in table format
+        // Repo arrays will be truncated if they contain more than 3 items
+        // Due to that, we will also write the results to a file
         console.table(languagesInOrg);
+
+        // Write results to file
+        fs.writeFile(outputFilePath, JSON.stringify(languagesInOrg, null, 2), (err) => {
+            if (err) {
+                console.error(err);
+                return;
+            }
+            console.log(`Output file has been created: '${outputFilePath}'`);
+        });
     },
 };


### PR DESCRIPTION
### Details
If there are more than 3 repos that include a language, the table which is printed to the console truncates the array of repo names. Due to this we are adding the creation of a JSON format output file to ensure all repo names are available to the user.

The changes in this PR allow for the following:
- User to provide output file name via `-f` arg (with optional pre-existing relative or full path)
  - If not provided a file will be created in the current working directory in the format `languages-in-organization.<organization>.<datetime>.json`
- Creation of output file in JSON format

### Commits
- fix: resolve linting issues
- feat: create output file in JSON format

### Supporting screenshots
- Example console output WITH output file specified:
  <img width="1269" alt="image" src="https://user-images.githubusercontent.com/77471034/233202411-f0415bcf-b94a-4bd7-9819-0563943d0c9d.png">
- Example output without output file path specified:
  ![image](https://user-images.githubusercontent.com/77471034/233201998-e3eaa96e-83be-49e8-98fe-cf3e9d150855.png)
- `node cli.js list-languages-in-organization --help` now displays `-f` option:
  <img width="991" alt="image" src="https://user-images.githubusercontent.com/77471034/233200538-0db26659-ba09-48c0-8471-971340438eb5.png">

### Output file (renamed to `.txt` in order to attach here)
- [languages-in-organization.actions.2023-04-19T21:12:44.745Z.txt](https://github.com/liatrio/github-scripts/files/11277695/languages-in-organization.actions.2023-04-19T21.12.44.745Z.txt)
